### PR TITLE
S86 volume envelope fix

### DIFF
--- a/src/s2x/wsg.c
+++ b/src/s2x/wsg.c
@@ -511,7 +511,6 @@ void S2X_S86WSGTrackUpdate(S2X_State *S,int TrackNo,S2X_Track *T)
             {
                 T->SyncFlag = T->Channel[ch].WSG.SyncFlag;
                 S2X_VoiceCommand(S,&T->Channel[ch],0,0);
-                S2X_S86WSGEnvelopeUpdate(S,&T->Channel[ch].WSG.Env[0],&T->Channel[ch]);
                 S2X_S86WSGChannelUpdate(S,TrackNo,&T->Channel[ch],ch);
             }
         }
@@ -847,6 +846,8 @@ void S2X_S86WSGChannelUpdate(S2X_State *S,int TrackNo,S2X_Channel *C,int Channel
 
         S2X_S86WSGEnvelopeStart(S,&C->WSG.Env[0]);
     }
+
+    S2X_S86WSGEnvelopeUpdate(S,&C->WSG.Env[0],C);
 
     C->WSG.Env[1].Val = C->WSG.Env[0].Val;
 


### PR DESCRIPTION
`S2X_S86WSGTrackUpdate` calls `S2X_S86WSGEnvelopeUpdate` before `S2X_S86WSGChannelUpdate` which causes an issue at the very first track update. I think that the envelope flag is set and no update is being performed resulting in zero volumes. I have looked at the S1 equivalent and saw that `S2X_S1WSGEnvelopeUpdate` is called within the `S2X_S1WSGChannelUpdate` which is the proposed fix for the S86 driver. I have checked that solution against the register dumps from Mame and it seems that it fixes the issue but I am not sure if that does not have any other side effects. Can you please have a look and see if that makes sense?